### PR TITLE
Regenerate markers when indent size changes

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -6,6 +6,7 @@
     <title>CodeMirror Indentation Markers</title>
   </head>
   <body>
+    <button id="toggleIndent">Toggle indent size between 2 and 4</button>
     <div id="editor"></div>
     <script type="module" src="./index.ts"></script>
   </body>

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -1,36 +1,47 @@
 import { basicSetup } from 'codemirror';
 import { EditorView } from '@codemirror/view';
-import { EditorState } from '@codemirror/state';
+import { Compartment, EditorState } from '@codemirror/state';
+import {getIndentUnit, indentUnit} from '@codemirror/language';
 import { python } from '@codemirror/lang-python';
 import { indentationMarkers } from '../src';
 
 const doc = `
 def read_file(path):
-  with open(path, 'r') as file:
+    with open(path, 'r') as file:
 
-    print("opening file")
-    text = file.read()
-
-    file.close()
-
-    if len(text) > 1000:
-      print("thats a big file!")
-
-    return text
+        print("opening file")
+        text = file.read()
+    
+        file.close()
+    
+        if len(text) > 1000:
+            print("thats a big file!")
+    
+        return text
 
 def main():
-  read_file("notes.txt")
+    read_file("notes.txt")
 `
 
-new EditorView({
+const indentConf = new Compartment()
+
+const view = new EditorView({
   state: EditorState.create({
     doc,
 
     extensions: [
       basicSetup,
       python(),
+      indentConf.of(indentUnit.of('  ')),
       indentationMarkers(),
     ],
   }),
   parent: document.querySelector('#editor'),
 });
+
+function toggleIndent() {
+  const indent = (getIndentUnit(view.state) === 2) ? '    ' : '  '
+  view.dispatch({ effects: indentConf.reconfigure(indentUnit.of(indent)) })
+}
+
+document.getElementById('toggleIndent').addEventListener('click', toggleIndent)

--- a/dev/vite.config.js
+++ b/dev/vite.config.js
@@ -1,8 +1,15 @@
+const isReplit = Boolean(process.env.REPL_SLUG);
+
 export default {
   server: {
     host: '0.0.0.0',
-    hmr: {
-      clientPort: 443,
-    }
+
+    ...(isReplit
+        ? {
+          hmr: {
+            clientPort: 443,
+          },
+        }
+        : {}),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,12 @@ class IndentMarkersClass implements PluginValue {
   }
 
   update(update: ViewUpdate) {
-    if (update.docChanged || update.viewportChanged || update.selectionSet) {
+    const unitWidth = getIndentUnit(update.state);
+    const unitWidthChanged = unitWidth !== this.unitWidth
+    if (unitWidthChanged) {
+      this.unitWidth = unitWidth
+    }
+    if (update.docChanged || update.viewportChanged || update.selectionSet || unitWidthChanged) {
       this.generate(update.state);
     }
   }


### PR DESCRIPTION
# Why

<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->
When the indentation size changes (which could happen, for example, when changing language, or when the user changes a preference), the indentation markers should, ideally, change to reflect that. They currently don't.


# What changed

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->
I added check on every update that causes the markers to be regenerated if the indent size has changed. I also added a button to change indent size on the dev page.

In an unrelated change, I changed the Vite config so that there aren't HMR errors in non-Replit environments.

# Test plan

<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->

1. Reconfigure a CM6 editor to change the indent size. The change to the dev page has an example of doing this
2. Indent markers should redraw to reflect the change
