### PR TITLE
Add workaround for subpixel rounding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ const MARKER_COLOR_DARK = '#2B3245';
 const MARKER_COLOR_ACTIVE_LIGHT = '#E4E5E6';
 const MARKER_COLOR_ACTIVE_DARK = '#3C445C';
 
-/** Thickness of indent markers. Probably should be integer pixel values. */
-const MARKER_THICKNESS = '1px';
+/** Thickness of indent markers */
+const MARKER_THICKNESS = 1;
 
 const indentTheme = EditorView.baseTheme({
   '&light': {
@@ -60,8 +60,9 @@ const indentTheme = EditorView.baseTheme({
 });
 
 function createGradient(markerCssProperty: string, indentWidth: number, startOffset: number, columns: number) {
-  const gradient = `repeating-linear-gradient(to right, var(${markerCssProperty}) 0 ${MARKER_THICKNESS}, transparent ${MARKER_THICKNESS} ${indentWidth}ch)`
-  // Subtract one pixel from the background width to get rid of artifacts of pixel rounding
+  // the .2px offset to the MARKER_THICKNESS is to make sure that the marker is not removed by subpixel rounding
+  const gradient = `repeating-linear-gradient(to right, var(${markerCssProperty}) 0 ${MARKER_THICKNESS}px, transparent ${MARKER_THICKNESS + .2}px ${indentWidth}ch)`
+  // Subtract one pixel from the background width to get rid of artifacts of pixel rounding at the end of the gradient
   return `${gradient} ${startOffset * indentWidth}.5ch/calc(${indentWidth * columns}ch - 1px) no-repeat`
 }
 


### PR DESCRIPTION
# Why
**This is a workaround, and very much a request-for-comments if you can come up with a better idea**
<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->
After merging #12 yesterday, I've noticed that the Firefox subpixel rounding removes the marker at some font sizes / marker width levels.



# What changed

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->
I think it happens since `1ch` is a fractional value, hence the browser will have to do some rounding in the repeating pattern. What I cannot answer, however, is why this rounding sacrifices the 1px marker rather than the heap of transparent content right next to it. 

The solution to add a little bit of "padding" to the marker is not great, but it's the best I could come up with that seemed to fix in all of my test cases. 

Sorry for not catching this in yesterdays PR. 

Before: 
![Screenshot from 2023-03-23 16-18-41](https://user-images.githubusercontent.com/3295293/227268824-2f4f5476-d124-4b49-af89-b8c490f66cc8.png)

After:
![Screenshot from 2023-03-23 16-20-50](https://user-images.githubusercontent.com/3295293/227268841-2e518b9b-00bf-4880-8bc9-06e0371eaa13.png)


