### PR TITLE
add new indentation marker option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ optional properties:
 
     Boolean that determines whether markers in the first column are omitted.
     Defaults to `false`.
+  
+- `markerType`
+  
+    String that determines how far the indentation markers extend. `"fullScope"` indicates that the markers extend down the full height of a scope. With the `"codeOnly"` option, indentation markers terminate at the last nonempty line in a scope. Defaults to `"fullScope"`.
 
 #### Example
 
@@ -62,6 +66,7 @@ new EditorView({
       indentationMarkers({
         highlightActiveBlock: false,
         hideFirstIndent: true,
+        markerType: "codeOnly",
       })
     ],
   }),

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,11 @@ export interface IndentationMarkerConfiguration {
      * Determines whether markers in the first column are omitted.
      */
     hideFirstIndent?: boolean
+
+    /**
+     * Determines the type of indentation marker.
+     */
+    markerType?: "fullScope" | "codeOnly"
 }
 
 export const indentationMarkerConfig = Facet.define<IndentationMarkerConfiguration, Required<IndentationMarkerConfiguration>>({
@@ -17,6 +22,7 @@ export const indentationMarkerConfig = Facet.define<IndentationMarkerConfigurati
         return combineConfig(configs, {
             highlightActiveBlock: true,
             hideFirstIndent: false,
+            markerType: "fullScope"
         });
     }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,8 +136,9 @@ class IndentMarkersClass implements PluginValue {
     const builder = new RangeSetBuilder<Decoration>();
 
     const lines = getVisibleLines(this.view, state);
-    const map = new IndentationMap(lines, state, this.unitWidth);
-    const { hideFirstIndent } = state.facet(indentationMarkerConfig)
+    const { hideFirstIndent, markerType } = state.facet(indentationMarkerConfig)
+    const map = new IndentationMap(lines, state, this.unitWidth, markerType);
+
 
     for (const line of lines) {
       const entry = map.get(line.number);

--- a/src/map.ts
+++ b/src/map.ts
@@ -32,16 +32,21 @@ export class IndentationMap {
   /** The width of the editor's indent unit. */
   private unitWidth: number;
 
+  /** The type of indentation to use (terminate at end of scope vs last non-empty line in scope) */
+  private markerType: "fullScope" | "codeOnly";
+
   /**
    * @param lines - The set of lines to get the indentation map for.
    * @param state - The {@link EditorState} to derive the indentation map from.
    * @param unitWidth - The width of the editor's indent unit.
+   * @param markerType - The type of indentation to use (terminate at end of scope vs last line of code in scope)
    */
-  constructor(lines: Set<Line>, state: EditorState, unitWidth: number) {
+  constructor(lines: Set<Line>, state: EditorState, unitWidth: number, markerType: "fullScope" | "codeOnly") {
     this.lines = lines;
     this.state = state;
     this.map = new Map();
     this.unitWidth = unitWidth;
+    this.markerType = markerType;
 
     for (const line of this.lines) {
       this.add(line);
@@ -120,8 +125,9 @@ export class IndentationMap {
       const prev = this.closestNonEmpty(line, -1);
       const next = this.closestNonEmpty(line, 1);
 
-      // if the next line ends the block, we'll use the previous line's indentation
-      if (prev.level >= next.level) {
+      // if the next line ends the block and the marker type is not set to codeOnly,
+        // we'll just use the previous line's indentation
+      if (prev.level >= next.level && this.markerType !== "codeOnly" ) {
         return this.set(line, 0, prev.level);
       }
 


### PR DESCRIPTION
# Why 
- This change introduces a new indentation marker option that can enhance code readability and align with personal coding styles.
- While this option can be applied across various languages, I think it works particularly well with languages that have indentation-sensitive syntax like Python or Yaml, making it a valuable addition for those working with them.
# What changed
- Added a new option in the `IndentationMarkerConfiguration` interface that allows users to choose between two types of indentation markers--`fullScope` and `codeOnly`. 
- Adjusted the indentation guides behavior to support both types, giving users the flexibility to choose according to their preference.
- Here's a before-and-after comparison that illustrates the new `codeOnly` behavior:

**Before** (`fullScope`):
<img width="431" alt="Screenshot 2023-08-06 at 8 33 39 PM" src="https://github.com/replit/codemirror-indentation-markers/assets/35574885/67a13b48-578f-4a53-ba64-8b663feb799f">

**After** (`codeOnly`): 
<img width="431" alt="Screenshot 2023-08-06 at 8 33 27 PM" src="https://github.com/replit/codemirror-indentation-markers/assets/35574885/af862522-f878-4c44-a923-49c5f94c8bdd">
- The `fullScope` behavior remains as the default, preserving existing functionality for those who prefer it.
# Test Plan
The new option can be applied like this:
```javascript
indentationMarkers({
  hideFirstIndent: false,
  highlightActiveBlock: true,
  markerType: "codeOnly", // The new option
}),
```
- **Toggle**: Verify that the new indentation guide option can be toggled between the two options.
- **Various Languages Support**: Open code files in different programming languages and ensure that indentation guides only extend down to code within the scope.
- **Edge Cases**: Ensure indentation guides are correct when indentations are mixed, nested, and/or inconsistent. Ensure default is displayed when invalid option is passed in.