### PR TITLE
Add options to customize marker thickness and colors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ optional properties:
   
     String that determines how far the indentation markers extend. `"fullScope"` indicates that the markers extend down the full height of a scope. With the `"codeOnly"` option, indentation markers terminate at the last nonempty line in a scope. Defaults to `"fullScope"`.
 
+- `thickness`
+
+    Integer that determines the thickness in pixels of the indentation markers. Defaults to `1`.
+
+- `colors`
+
+    Object that determines the colors of the indentation markers.
+
+    - `light`
+
+        String that determines the color of the markers when the editor has a light theme. Defaults to `#F0F1F2`.
+
+    - `dark`
+
+        String that determines the color of the markers when the editor has a dark theme. Defaults to `#2B3245`.
+
+    - `activeLight`
+
+        String that determines the color of the active block marker when the editor has a light theme. Only applies if `highlightActiveBlock` is `true`. Defaults to `#E4E5E6`.
+
+    - `activeDark`
+
+        String that determines the color of the active block marker when the editor has a dark theme. Only applies if `highlightActiveBlock` is `true`. Defaults to `#3C445C`.
+
 #### Example
 
 ```ts
@@ -67,6 +91,13 @@ new EditorView({
         highlightActiveBlock: false,
         hideFirstIndent: true,
         markerType: "codeOnly",
+        thickness: 2,
+        colors: {
+          light: 'LightBlue',
+          dark: 'DarkBlue',
+          activeLight: 'LightGreen',
+          activeDark: 'DarkGreen',
+        }
       })
     ],
   }),

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,36 @@ export interface IndentationMarkerConfiguration {
      * Determines the type of indentation marker.
      */
     markerType?: "fullScope" | "codeOnly"
+
+    /**
+     * Determines the thickness of marker (in pixels).
+     */
+    thickness?: number
+
+    /**
+     * Determines the color of marker.
+     */
+    colors?: {
+        /**
+         * Color of inactive indent markers when using a light theme.
+         */
+        normalLight?: string
+
+        /**
+         * Color of inactive indent markers when using a dark theme.
+         */
+        normalDark?: string
+
+        /**
+         * Color of active indent markers when using a light theme.
+         */
+        activeLight?: string
+
+        /**
+         * Color of active indent markers when using a dark theme.
+         */
+        activeDark?: string
+    }
 }
 
 export const indentationMarkerConfig = Facet.define<IndentationMarkerConfiguration, Required<IndentationMarkerConfiguration>>({
@@ -22,7 +52,8 @@ export const indentationMarkerConfig = Facet.define<IndentationMarkerConfigurati
         return combineConfig(configs, {
             highlightActiveBlock: true,
             hideFirstIndent: false,
-            markerType: "fullScope"
+            markerType: "fullScope",
+            thickness: 1,
         });
     }
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,12 +28,12 @@ export interface IndentationMarkerConfiguration {
         /**
          * Color of inactive indent markers when using a light theme.
          */
-        normalLight?: string
+        light?: string
 
         /**
          * Color of inactive indent markers when using a dark theme.
          */
-        normalDark?: string
+        dark?: string
 
         /**
          * Color of active indent markers when using a light theme.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,58 +15,45 @@ import { IndentationMarkerConfiguration, indentationMarkerConfig } from "./confi
 // CSS classes:
 // - .cm-indent-markers
 
-// CSS variables:
-// - --indent-marker-bg-part
-// - --indent-marker-active-bg-part
-
-/** Color of inactive indent markers. Based on RUI's var(--background-higher) */
-const MARKER_COLOR_LIGHT = '#F0F1F2';
-const MARKER_COLOR_DARK = '#2B3245';
-
-/** Color of active indent markers. Based on RUI's var(--background-highest) */
-const MARKER_COLOR_ACTIVE_LIGHT = '#E4E5E6';
-const MARKER_COLOR_ACTIVE_DARK = '#3C445C';
-
-/** Thickness of indent markers. Probably should be integer pixel values. */
-const MARKER_THICKNESS = '1px';
-
-const indentTheme = EditorView.baseTheme({
-  '&light': {
-    '--indent-marker-bg-color': MARKER_COLOR_LIGHT,
-    '--indent-marker-active-bg-color': MARKER_COLOR_ACTIVE_LIGHT
-  },
+function createIndentTheme(colors) {
+  return EditorView.baseTheme({
+    '&light': {
+      '--indent-marker-bg-color': colors.normalLight,
+      '--indent-marker-active-bg-color': colors.activeLight,
+    },
+    
+    '&dark': {
+      '--indent-marker-bg-color': colors.normalDark,
+      '--indent-marker-active-bg-color': colors.activeDark,
+    },
   
-  '&dark': {
-    '--indent-marker-bg-color': MARKER_COLOR_DARK,
-    '--indent-marker-active-bg-color': MARKER_COLOR_ACTIVE_DARK
-  },
+    '.cm-line': {
+      position: 'relative',
+    },
+  
+    // this pseudo-element is used to draw the indent markers,
+    // while still allowing the line to have its own background.
+    '.cm-indent-markers::before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      background: 'var(--indent-markers)',
+      pointerEvents: 'none',
+      zIndex: '-1',
+    },
+  });
+}
 
-  '.cm-line': {
-    position: 'relative',
-  },
-
-  // this pseudo-element is used to draw the indent markers,
-  // while still allowing the line to have its own background.
-  '.cm-indent-markers::before': {
-    content: '""',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    background: 'var(--indent-markers)',
-    pointerEvents: 'none',
-    zIndex: '-1',
-  },
-});
-
-function createGradient(markerCssProperty: string, indentWidth: number, startOffset: number, columns: number) {
-  const gradient = `repeating-linear-gradient(to right, var(${markerCssProperty}) 0 ${MARKER_THICKNESS}, transparent ${MARKER_THICKNESS} ${indentWidth}ch)`
+function createGradient(markerCssProperty: string, thickness: number, indentWidth: number, startOffset: number, columns: number) {
+  const gradient = `repeating-linear-gradient(to right, var(${markerCssProperty}) 0 ${thickness}px, transparent ${thickness}px ${indentWidth}ch)`
   // Subtract one pixel from the background width to get rid of artifacts of pixel rounding
   return `${gradient} ${startOffset * indentWidth}.5ch/calc(${indentWidth * columns}ch - 1px) no-repeat`
 }
 
-function makeBackgroundCSS(entry: IndentEntry, indentWidth: number, hideFirstIndent: boolean) {
+function makeBackgroundCSS(entry: IndentEntry, indentWidth: number, hideFirstIndent: boolean, thickness: number) {
   const { level, active } = entry;
   if (hideFirstIndent && level === 0) {
     return [];
@@ -78,20 +65,20 @@ function makeBackgroundCSS(entry: IndentEntry, indentWidth: number, hideFirstInd
     const markersBeforeActive = active - startAt - 1;
     if (markersBeforeActive > 0) {
       backgrounds.push(
-        createGradient('--indent-marker-bg-color', indentWidth, startAt, markersBeforeActive),
+        createGradient('--indent-marker-bg-color', thickness, indentWidth, startAt, markersBeforeActive),
       );
     }
     backgrounds.push(
-      createGradient('--indent-marker-active-bg-color', indentWidth, active - 1, 1),
+      createGradient('--indent-marker-active-bg-color', thickness, indentWidth, active - 1, 1),
     );
     if (active !== level) {
       backgrounds.push(
-        createGradient('--indent-marker-bg-color', indentWidth, active, level - active)
+        createGradient('--indent-marker-bg-color', thickness, indentWidth, active, level - active)
       );
     }
   } else {
     backgrounds.push(
-      createGradient('--indent-marker-bg-color', indentWidth, startAt, level - startAt)
+      createGradient('--indent-marker-bg-color', thickness, indentWidth, startAt, level - startAt)
     );
   }
 
@@ -136,7 +123,7 @@ class IndentMarkersClass implements PluginValue {
     const builder = new RangeSetBuilder<Decoration>();
 
     const lines = getVisibleLines(this.view, state);
-    const { hideFirstIndent, markerType } = state.facet(indentationMarkerConfig)
+    const { hideFirstIndent, markerType, thickness } = state.facet(indentationMarkerConfig);
     const map = new IndentationMap(lines, state, this.unitWidth, markerType);
 
 
@@ -147,7 +134,7 @@ class IndentMarkersClass implements PluginValue {
         continue;
       }
 
-      const backgrounds = makeBackgroundCSS(entry, this.unitWidth, hideFirstIndent);
+      const backgrounds = makeBackgroundCSS(entry, this.unitWidth, hideFirstIndent, thickness);
 
       builder.add(
         line.from,
@@ -166,9 +153,21 @@ class IndentMarkersClass implements PluginValue {
 }
 
 export function indentationMarkers(config: IndentationMarkerConfiguration = {}) {
+  const defaultColors = {
+    normalLight: '#F0F1F2',
+    normalDark: '#2B3245',
+    activeLight: '#E4E5E6',
+    activeDark: '#3C445C',
+  };
+
+  let colors = defaultColors;
+  if (config.colors) {
+    colors = {...defaultColors, ...config.colors};
+  }
+
   return [
     indentationMarkerConfig.of(config),
-    indentTheme,
+    createIndentTheme(colors),
     ViewPlugin.fromClass(IndentMarkersClass, {
       decorations: (v) => v.decorations,
     }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,15 +15,15 @@ import { IndentationMarkerConfiguration, indentationMarkerConfig } from "./confi
 // CSS classes:
 // - .cm-indent-markers
 
-function createIndentTheme(colors) {
+function indentTheme(colors) {
   return EditorView.baseTheme({
     '&light': {
-      '--indent-marker-bg-color': colors.normalLight,
+      '--indent-marker-bg-color': colors.light,
       '--indent-marker-active-bg-color': colors.activeLight,
     },
     
     '&dark': {
-      '--indent-marker-bg-color': colors.normalDark,
+      '--indent-marker-bg-color': colors.dark,
       '--indent-marker-active-bg-color': colors.activeDark,
     },
   
@@ -154,8 +154,8 @@ class IndentMarkersClass implements PluginValue {
 
 export function indentationMarkers(config: IndentationMarkerConfiguration = {}) {
   const defaultColors = {
-    normalLight: '#F0F1F2',
-    normalDark: '#2B3245',
+    light: '#F0F1F2',
+    dark: '#2B3245',
     activeLight: '#E4E5E6',
     activeDark: '#3C445C',
   };
@@ -167,7 +167,7 @@ export function indentationMarkers(config: IndentationMarkerConfiguration = {}) 
 
   return [
     indentationMarkerConfig.of(config),
-    createIndentTheme(colors),
+    indentTheme(colors),
     ViewPlugin.fromClass(IndentMarkersClass, {
       decorations: (v) => v.decorations,
     }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,19 @@ import { IndentationMarkerConfiguration, indentationMarkerConfig } from "./confi
 // CSS classes:
 // - .cm-indent-markers
 
-function indentTheme(colors) {
+function indentTheme(colorOptions: IndentationMarkerConfiguration['colors']) {
+  const defaultColors = {
+    light: '#F0F1F2',
+    dark: '#2B3245',
+    activeLight: '#E4E5E6',
+    activeDark: '#3C445C',
+  };
+
+  let colors = defaultColors;
+  if (colorOptions) {
+    colors = {...defaultColors, ...colorOptions};
+  }
+
   return EditorView.baseTheme({
     '&light': {
       '--indent-marker-bg-color': colors.light,
@@ -153,21 +165,9 @@ class IndentMarkersClass implements PluginValue {
 }
 
 export function indentationMarkers(config: IndentationMarkerConfiguration = {}) {
-  const defaultColors = {
-    light: '#F0F1F2',
-    dark: '#2B3245',
-    activeLight: '#E4E5E6',
-    activeDark: '#3C445C',
-  };
-
-  let colors = defaultColors;
-  if (config.colors) {
-    colors = {...defaultColors, ...config.colors};
-  }
-
   return [
     indentationMarkerConfig.of(config),
-    indentTheme(colors),
+    indentTheme(config.colors),
     ViewPlugin.fromClass(IndentMarkersClass, {
       decorations: (v) => v.decorations,
     }),


### PR DESCRIPTION
# Why

<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->

The color and thickness of indentation markers are currently hard-coded based on the Replit User Interface. Although they are good default values, we should have the flexibility to configure them.

# What changed

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->

- Added a new option in ```IndentationMarkerConfiguration``` called ```thickness``` that lets the user specify the thickness of the indentation marker (in pixels).
- Added new options in ```IndentationMarkerConfiguration``` under the ```colors``` option that allows the user to specify the color of active and normal lines under light and dark themes.
- Here's an example of the beautiful new styles you can create:

![image](https://github.com/replit/codemirror-indentation-markers/assets/84098504/9a2c3ef7-b0e9-40b1-843a-3b637420a2ab)

(FYI, I'm new to CodeMirror 6 and Typescript, so let me know if I'm doing something wrong)

# Test plan

<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->
The new options can be applied like this:
```typescript
indentationMarkers({
  thickness: 10,
  colors: {
    activeLight: 'blue',
    normalLight: 'red',
  },
})
```