### PR TITLE
Move indent markers in front of other elements.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ function indentTheme(colorOptions: IndentationMarkerConfiguration['colors']) {
       bottom: 0,
       background: 'var(--indent-markers)',
       pointerEvents: 'none',
-      zIndex: '-1',
+      zIndex: '100',
     },
   });
 }


### PR DESCRIPTION
# Why
I've been doing some CodeMirror theming, and I noticed that the selection highlighting can obscure the indentation markers because the markers have ```z-index: -1```. Also, the markers turn blue-ish when the color of the indentation markers combines with the color of the active line highlighting.
<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->

# What changed
Changed it to ```z-index: 100```. I can't think of any reason why you would want markers below other elements, but if necessary, we can make z-index a configuration option.
<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->
