### PR TITLE
Proof-of-concept fix for variable-width bug

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <button id="toggleIndent">Toggle indent size between 2 and 4</button>
+    <button id="toggleFont">Toggle font between monospace and variable-width</button>
     <div id="editor"></div>
     <script type="module" src="./index.ts"></script>
   </body>

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -44,4 +44,14 @@ function toggleIndent() {
   view.dispatch({ effects: indentConf.reconfigure(indentUnit.of(indent)) })
 }
 
+function toggleFont() {
+  let cmScroller = document.querySelector('.cm-scroller') as HTMLDivElement;
+  if (cmScroller.style.fontFamily === 'sans-serif') {
+    cmScroller.style.removeProperty('font-family');
+  } else {
+    cmScroller.style.fontFamily = 'sans-serif';
+  }
+}
+
 document.getElementById('toggleIndent').addEventListener('click', toggleIndent)
+document.getElementById('toggleFont').addEventListener('click', toggleFont)


### PR DESCRIPTION
This is a proof-of-concept fix for #25. It's very buggy, so don't merge it.

Screenshot:

<img width="494" alt="image" src="https://github.com/replit/codemirror-indentation-markers/assets/524783/dfe75ffd-d51b-4cd0-b2a1-6a57bb522480">
