### PR TITLE
Marker offsets wrong for variable-width (sans-serif) fonts 

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <button id="toggleIndent">Toggle indent size between 2 and 4</button>
+    <button id="toggleFont">Toggle font between monospace and variable-width</button>
     <div id="editor"></div>
     <script type="module" src="./index.ts"></script>
   </body>

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -44,4 +44,14 @@ function toggleIndent() {
   view.dispatch({ effects: indentConf.reconfigure(indentUnit.of(indent)) })
 }
 
+function toggleFont() {
+  let cmScroller = document.querySelector('.cm-scroller') as HTMLDivElement;
+  if (cmScroller.style.fontFamily === 'sans-serif') {
+    cmScroller.style.removeProperty('font-family');
+  } else {
+    cmScroller.style.fontFamily = 'sans-serif';
+  }
+}
+
 document.getElementById('toggleIndent').addEventListener('click', toggleIndent)
+document.getElementById('toggleFont').addEventListener('click', toggleFont)


### PR DESCRIPTION
The offsets for the indent markers are wrong for variable-width fonts.

<img width="500" alt="image" src="https://github.com/replit/codemirror-indentation-markers/assets/524783/cd7bd840-e5db-4c3a-a1c4-9075e42a1c39">

This pull request adds a button to repro the behavior, as shown in the screenshot.

The reason seems to be that we're using `${indentWidth}ch` (see [index.ts:63](https://github.com/replit/codemirror-indentation-markers/blob/8d8e5d135aba4e052cd37537b596441d3357dca6/src/index.ts#L63)), and for variable-width fonts, the `ch` CSS unit isn't the same as the width of one blank space.

I posted a proof-of-concept fix at #24, which demonstrates that we can use `coordsAtPos` to get the real indent width (see [these lines](https://github.com/replit/codemirror-indentation-markers/pull/24/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R153-R154)). I have no prior experience with CodeMirror, so it's almost certainly wrong and buggy in multiple ways.

Some thoughts:

- If we want to try and fix this by taking real DOM measurements, it should probably be behind a flag. Most users use monospace fonts, and we don't want to slow them down.
- In my proof-of-concept fix, I'm on purpose measuring the indent width for every line, rather than measuring once. My use case is a variable-width markdown editor, where code blocks still appear in monospace. In the following screenshot of my CodeMirror instance, the rectangles highlighted in red each contain two blank spaces. As you can see, the pixel width of a two-space indent depends on the line.

<img width="293" alt="image" src="https://github.com/replit/codemirror-indentation-markers/assets/524783/7da8d6ad-3428-4687-8661-70d349a3aa7f">