### PR TITLE
🧹  Adjust indentation markers by 2px to match `.cm-line`

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,14 +1,20 @@
 run="yarn run dev"
 
 entrypoint = "src/index.ts"
+hidden = [".config", "package-lock.json"]
+modules = ["nodejs-20:v8-20230920-bd784b9"]
 
-[packager]
-language = "nodejs-yarn"
-[packager.features]
-packageSearch = true
-guessImports = true
+[nix]
+channel = "stable-23_05"
 
-[languages.js]
-pattern = "**/*.ts"
-[languages.js.languageServer]
-start = ["typescript-language-server", "--stdio"]
+[gitHubImport]
+requiredFiles = [".replit", "replit.nix", "package.json", "package-lock.json"]
+
+[deployment]
+run = ["node", "index.js"]
+deploymentTarget = "cloudrun"
+ignorePorts = false
+
+[[ports]]
+localPort = 3000
+externalPort = 80

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -36,7 +36,7 @@ const view = new EditorView({
       indentationMarkers(),
     ],
   }),
-  parent: document.querySelector('#editor'),
+  parent: document.getElementById('editor'),
 });
 
 function toggleIndent() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/codemirror-indentation-markers",
   "description": "Render indentation markers in CodeMirror",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "author": {
     "name": "Sergei Chestakov",
     "email": "me@sergei.com"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/codemirror-indentation-markers",
   "description": "Render indentation markers in CodeMirror",
-  "version": "6.5.1",
+  "version": "6.5.0",
   "author": {
     "name": "Sergei Chestakov",
     "email": "me@sergei.com"

--- a/replit.nix
+++ b/replit.nix
@@ -1,7 +1,0 @@
-{ pkgs }: {
-	deps = [
-		pkgs.nodejs-16_x
-    pkgs.nodePackages.yarn
-    pkgs.nodePackages.typescript-language-server
-	];
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { getIndentUnit } from '@codemirror/language';
-import { combineConfig, EditorState, Facet, RangeSetBuilder } from '@codemirror/state';
+import { EditorState, RangeSetBuilder } from '@codemirror/state';
 import {
   Decoration,
   ViewPlugin,
@@ -49,7 +49,9 @@ function indentTheme(colorOptions: IndentationMarkerConfiguration['colors']) {
       content: '""',
       position: 'absolute',
       top: 0,
-      left: 0,
+      // .cm-line has a padding of 2px 
+      // https://github.com/codemirror/view/blob/1c0a0880fc904714339f059658f3ba3a88bb8e6e/src/theme.ts#L85
+      left: `2px`, 
       right: 0,
       bottom: 0,
       background: 'var(--indent-markers)',


### PR DESCRIPTION
# Why

<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->

This has bugged me for a while. `.cm-line` applies a 2px padding, so the indentation markers just look slightly off always

Before:
![Screen Shot 2024-03-13 at 3 19 48 PM](https://github.com/replit/codemirror-indentation-markers/assets/16962017/62c2fbb3-cedd-4d0b-a5ce-464ca7a7d220)

After: 
![Screen Shot 2024-03-13 at 3 19 12 PM](https://github.com/replit/codemirror-indentation-markers/assets/16962017/79479cb5-4482-4286-acfb-3ea81b9eb648)






Also cleaned up some .replit/replit.nix stuff to use nix modules

# What changed

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->

# Test plan

<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->
