### PR TITLE
Add option to customize active marker thickness

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ optional properties:
 
     Integer that determines the thickness in pixels of the indentation markers. Defaults to `1`.
 
+- `activeThickness`
+
+    Integer that determines the thickness in pixels of the active indentation markers. `-1` means to use `thickness`. Defaults to `-1`.
+
 - `colors`
 
     Object that determines the colors of the indentation markers.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ optional properties:
 
 - `activeThickness`
 
-    Integer that determines the thickness in pixels of the active indentation markers. `-1` means to use `thickness`. Defaults to `-1`.
+    Integer that determines the thickness in pixels of the active indentation markers. If `undefined` or `null` then `thickness` will be used. Defaults to `undefined`.
 
 - `colors`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,13 @@ export interface IndentationMarkerConfiguration {
     thickness?: number
 
     /**
+     * Determines the thickness of active marker (in pixels).
+     *
+     * 0 to use regular thickness.
+     */
+    activeThickness?: number
+
+    /**
      * Determines the color of marker.
      */
     colors?: {
@@ -54,6 +61,7 @@ export const indentationMarkerConfig = Facet.define<IndentationMarkerConfigurati
             hideFirstIndent: false,
             markerType: "fullScope",
             thickness: 1,
+            thickness: -1,
         });
     }
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,7 @@ export interface IndentationMarkerConfiguration {
     /**
      * Determines the thickness of active marker (in pixels).
      *
-     * 0 to use regular thickness.
+     * If undefined or null, then regular thickness will be used.
      */
     activeThickness?: number
 
@@ -61,7 +61,6 @@ export const indentationMarkerConfig = Facet.define<IndentationMarkerConfigurati
             hideFirstIndent: false,
             markerType: "fullScope",
             thickness: 1,
-            thickness: -1,
         });
     }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,8 +67,9 @@ function createGradient(markerCssProperty: string, thickness: number, indentWidt
   return `${gradient} ${startOffset * indentWidth}.5ch/calc(${indentWidth * columns}ch - 1px) no-repeat`
 }
 
-function makeBackgroundCSS(entry: IndentEntry, indentWidth: number, hideFirstIndent: boolean, thickness: number) {
+function makeBackgroundCSS(entry: IndentEntry, indentWidth: number, hideFirstIndent: boolean, thickness: number, activeThickness: number) {
   const { level, active } = entry;
+  activeThickness = activeThickness === -1 ? thickness : activeThickness;
   if (hideFirstIndent && level === 0) {
     return [];
   }
@@ -83,7 +84,7 @@ function makeBackgroundCSS(entry: IndentEntry, indentWidth: number, hideFirstInd
       );
     }
     backgrounds.push(
-      createGradient('--indent-marker-active-bg-color', thickness, indentWidth, active - 1, 1),
+      createGradient('--indent-marker-active-bg-color', activeThickness, indentWidth, active - 1, 1),
     );
     if (active !== level) {
       backgrounds.push(
@@ -137,7 +138,7 @@ class IndentMarkersClass implements PluginValue {
     const builder = new RangeSetBuilder<Decoration>();
 
     const lines = getVisibleLines(this.view, state);
-    const { hideFirstIndent, markerType, thickness } = state.facet(indentationMarkerConfig);
+    const { hideFirstIndent, markerType, thickness, activeThickness } = state.facet(indentationMarkerConfig);
     const map = new IndentationMap(lines, state, this.unitWidth, markerType);
 
 
@@ -148,7 +149,7 @@ class IndentMarkersClass implements PluginValue {
         continue;
       }
 
-      const backgrounds = makeBackgroundCSS(entry, this.unitWidth, hideFirstIndent, thickness);
+      const backgrounds = makeBackgroundCSS(entry, this.unitWidth, hideFirstIndent, thickness, activeThickness);
 
       builder.add(
         line.from,

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ function createGradient(markerCssProperty: string, thickness: number, indentWidt
 
 function makeBackgroundCSS(entry: IndentEntry, indentWidth: number, hideFirstIndent: boolean, thickness: number, activeThickness: number) {
   const { level, active } = entry;
-  activeThickness = activeThickness === -1 ? thickness : activeThickness;
+  activeThickness = activeThickness ?? thickness;
   if (hideFirstIndent && level === 0) {
     return [];
   }


### PR DESCRIPTION
# Why

I'm using a subdued color for `color.light`, which looks good with width 2px.

I want to use a strong color for `color.activeLight` but the marker stands out too much when it's 2px, so I added an option to make the width configurable.

It's pretty specific, but maybe it will help someone else.

# What changed

 - Added a new option in `IndentationMarkerConfiguration` called `activeThickness` that lets the user specify the thickness of the active indentation marker (in pixels).

![shot](https://github.com/replit/codemirror-indentation-markers/assets/32057441/26f0b60d-d3a4-48f9-8321-e5f547b52585)

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->

# Test plan

I tested then new option like this:
``` js
           indentationMarkers({ highlightActiveBlock: true,
                                hideFirstIndent: true,
                                markerType: "codeOnly",
                                thickness: 2,
                                activeThickness: 1,
                                colors: {
                                  light: 'var(--clr-fill)',
                                  dark: 'var(--clr-fill)',
                                  activeLight: 'var(--clr-nb1)',
                                  activeDark: 'var(--clr-nb1)' } }),
```

<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->
