### PR TITLE
Allow Non-breaking Spaces

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,6 +61,10 @@ export function numColumns(str: string, tabSize: number) {
         col += 1;
         continue loop;
       }
+      case '\u00A0': {
+        col += 1;
+        continue loop;
+      }
 
       case '\t': {
         // if the current column is a multiple of the tab size, we can just

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,10 +57,7 @@ export function numColumns(str: string, tabSize: number) {
   // eslint-disable-next-line no-restricted-syntax
   loop: for (let i = 0; i < str.length; i++) {
     switch (str[i]) {
-      case ' ': {
-        col += 1;
-        continue loop;
-      }
+      case ' ':
       case '\u00A0': {
         col += 1;
         continue loop;


### PR DESCRIPTION
# Why

If the value string had non-breaking spaces ('\u00A0'), the indentation would not work. 

# What changed

A non-breaking space character is treated same as the space character

# Test plan

Test cases can be added which have non-breaking spaces as well as ordinary spaces in the input
