### PR TITLE
Fix: Use same amount of left pad as .cm-line

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,9 +49,9 @@ function indentTheme(colorOptions: IndentationMarkerConfiguration['colors']) {
       content: '""',
       position: 'absolute',
       top: 0,
-      // .cm-line has a padding of 2px 
+      // .cm-line has a padding-left of 6px.
       // https://github.com/codemirror/view/blob/1c0a0880fc904714339f059658f3ba3a88bb8e6e/src/theme.ts#L85
-      left: `2px`, 
+      left: '6px',
       right: 0,
       bottom: 0,
       background: 'var(--indent-markers)',
@@ -64,7 +64,7 @@ function indentTheme(colorOptions: IndentationMarkerConfiguration['colors']) {
 function createGradient(markerCssProperty: string, thickness: number, indentWidth: number, startOffset: number, columns: number) {
   const gradient = `repeating-linear-gradient(to right, var(${markerCssProperty}) 0 ${thickness}px, transparent ${thickness}px ${indentWidth}ch)`
   // Subtract one pixel from the background width to get rid of artifacts of pixel rounding
-  return `${gradient} ${startOffset * indentWidth}.5ch/calc(${indentWidth * columns}ch - 1px) no-repeat`
+  return `${gradient} ${startOffset * indentWidth}ch/calc(${indentWidth * columns}ch - 1px) no-repeat`
 }
 
 function makeBackgroundCSS(entry: IndentEntry, indentWidth: number, hideFirstIndent: boolean, thickness: number, activeThickness: number) {


### PR DESCRIPTION
# Why

The indent markers are drawn using backgrounds on a `::before` element that is placed on CodeMirror lines (`.cm-line`). The left offsets of the indent markers should match the left pad of the `.cm-line`, however there is an error in the calculation.

The left offset of the indent marker is made up of:
 - `0.5ch` that is added to the left offset of the background in `createGradient`
 - **plus** `2px` that is set as the left value of the `::before` element.

The `2px` was added in #26 by @bradymadden97 to try fix the alignment but if you look closely at [theme.tx#L85](https://github.com/codemirror/view/blob/1c0a0880fc904714339f059658f3ba3a88bb8e6e/src/theme.ts#L85) the `.cm-line` left pad is `6px` instead of `2px`.

The offset of `0.5ch` plus `2px` is coming close, but see for example how the line under the 6 is shifting as I increase the font size:
![before0](https://github.com/user-attachments/assets/1d7eccfa-2493-4aa1-ade5-b9cf74203ce8)
![before1](https://github.com/user-attachments/assets/987f13a0-5eef-486d-b8d7-236084122fd0)
![before3](https://github.com/user-attachments/assets/70290590-121e-40a1-9dea-6b9458f69918)

(Maybe zoom the first image yourself to see how far left it should be.)

This is because the size of `0.5ch` depends on the font size, whereas the CodeMirror `.cm-line` offset is always fixed at 6 pixels.

<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->

# What changed

Remove the extra `0.5ch` offset from the background and change the `::before` left from `2px` to `6px`.

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->

# Test plan

I tested using an app that uses CodeMirror. I enabled the indentation markers and then gradually increased the font size to confirm the drift. 

After the PR the line stays in place when I increase the font size:
![after0](https://github.com/user-attachments/assets/0208cea5-98f7-45ac-889a-3d5a86813fde)
![after1](https://github.com/user-attachments/assets/b0637f20-037b-42c5-907f-f6e2da56e00e)
![after3](https://github.com/user-attachments/assets/4889632f-cccd-4bff-ae70-11dddb36c7b4)
<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->

